### PR TITLE
MAVLink: Fix protocol matching to allow non-UDP protocols again

### DIFF
--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -52,3 +52,44 @@ def test_transcriber_raw(pcap, filename, protocol):
     check_with_validation_file(
         filename, stdout.decode("utf-8"), test_transcriber_raw.__name__
     )
+
+
+@pytest.mark.parametrize("pcap", [x[0] for x in RAW_FILES])
+def test_transcriber_all_protocols(pcap):
+    args = [
+        "--pcap",
+        pcap,
+        "--ipal.output",
+        "-",
+        "--crc",
+        "and",
+        "--timeout",
+        "1000",
+    ]
+    errno, stdout, stderr = transcriber(args)
+    assert stderr == b"" or b"WARNING:asyncio:Unknown child process" in stderr
+    assert errno == 0
+
+
+@pytest.mark.parametrize("pcap,protocol", [(x[0], x[2]) for x in RAW_FILES])
+def test_transcriber_all_other_protocols(pcap, protocol):
+    all_other_protocols = [x[2] for x in RAW_FILES if not x[2] == protocol]
+    args = (
+        [
+            "--pcap",
+            pcap,
+            "--protocols",
+        ]
+        + all_other_protocols
+        + [
+            "--ipal.output",
+            "-",
+            "--crc",
+            "and",
+            "--timeout",
+            "1000",
+        ]
+    )
+    errno, stdout, stderr = transcriber(args)
+    assert stderr == b"" or b"WARNING:asyncio:Unknown child process" in stderr
+    assert errno == 0

--- a/transcribers/mavlink.py
+++ b/transcribers/mavlink.py
@@ -11,6 +11,9 @@ class MAVLinkTranscriber(Transcriber):
 
     @classmethod
     def matches_protocol(self, pkt):
+        if "UDP" not in pkt:
+            return False
+
         port_matches = (
             int(pkt["UDP"].srcport) in settings.MAVLINK_PORT
             or int(pkt["UDP"].dstport) in settings.MAVLINK_PORT


### PR DESCRIPTION
Otherwise, as long as MAVLink transcriber is in the list of transcribers, there are crashes on non-UDP packets because the key "UDP" does not exist.